### PR TITLE
Lighten dark mode logo circle

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -33,8 +33,8 @@ const HeroSection = () => {
           </div>
           <div className="hidden md:flex justify-center relative animate-float">
             <div className="w-72 h-72 lg:w-96 lg:h-96 relative">
-              <div className="absolute inset-0 rounded-full bg-serif-blue/5 dark:bg-serif-blue/10 animate-pulse"></div>
-              <div className="absolute inset-4 rounded-full bg-serif-blue/10 dark:bg-serif-blue/20"></div>
+              <div className="absolute inset-0 rounded-full bg-serif-blue/5 dark:bg-serif-blue/15 animate-pulse"></div>
+              <div className="absolute inset-4 rounded-full bg-serif-blue/10 dark:bg-serif-blue/25"></div>
               <div className="absolute inset-0 flex items-center justify-center">
                 <SerifLogo size={180} animated={true} className="text-serif-blue/80 dark:text-serif-blue/90" />
               </div>

--- a/src/components/SerifLogo.tsx
+++ b/src/components/SerifLogo.tsx
@@ -54,7 +54,7 @@ const SerifLogo = ({ size = 80, className = '' }: SerifLogoProps) => {
       <defs />
       <g
         transform="translate(0.000000,500.000000) scale(0.100000,-0.100000)"
-        fill="#4a90e2ff" // dark mode logo color
+        fill="#63a5e9ff" // dark mode logo color (lightened)
         stroke="none"
       >
         <path


### PR DESCRIPTION
## Summary
- lighten the circle color in the dark logo SVG
- make the dark mode hero ring lighter

## Testing
- `npm run lint` *(fails: react-refresh only-export-components, no-empty-object-type, no-require-imports)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68445b31606c832faf74a9af666774cc